### PR TITLE
1.23

### DIFF
--- a/PVS_HealthCheck_ReadMe.rtf
+++ b/PVS_HealthCheck_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -47,21 +47,30 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \b\i\fs28\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink2 \slocked \ssemihidden \spriority9 Heading 2 Char;}{\s17\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext17 \sqformat \spriority1 \styrsid14894181 No Spacing;}{\*\cs18 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf19 \sbasedon10 \sunhideused \styrsid14894181 
 Hyperlink;}{\*\cs19 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf20\chshdng0\chcfpat0\chcbpat21 \sbasedon10 \ssemihidden \sunhideused \styrsid10227609 Mention;}{\*\cs20 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf22\chshdng0\chcfpat0\chcbpat23 
-\sbasedon10 \ssemihidden \sunhideused \styrsid4947640 Unresolved Mention;}}{\*\listtable{\list\listtemplateid-1612023500\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext
-\leveltemplateid-1088912668\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0\hres0\chhres0 \fi-720\li1080\lin1080 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext
-\leveltemplateid1670146738\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0\hres0\chhres0 \fi-720\li1800\lin1800 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0
-{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0
-{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0
-{\leveltext\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0
-{\leveltext\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0
-{\leveltext\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0
-{\leveltext\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0
-{\leveltext\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li6480\lin6480 }{\listname ;}\listid314996233}{\list\listtemplateid-1236917028\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0
-\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
-\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
-\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360
-\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0
-{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\sbasedon10 \ssemihidden \sunhideused \styrsid4947640 Unresolved Mention;}}{\*\listtable{\list\listtemplateid-1565240990\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693
+\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689
+\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691
+\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693
+\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689
+\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691
+\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693
+\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li6480\lin6480 }{\listname ;}\listid282074041}{\list\listtemplateid-1612023500\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0
+\levelindent0{\leveltext\leveltemplateid-1088912668\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0\hres0\chhres0 \fi-720\li1080\lin1080 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0
+\levelindent0{\leveltext\leveltemplateid1670146738\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0\hres0\chhres0 \fi-720\li1800\lin1800 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative
+\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
+\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
+\levelspace0\levelindent0{\leveltext\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative
+\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
+\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
+\levelspace0\levelindent0{\leveltext\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative
+\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li6480\lin6480 }{\listname ;}\listid314996233}{\list\listtemplateid-1236917028\listhybrid{\listlevel\levelnfc23
+\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0
+\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1
+\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
+\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360
+\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
 \leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
 \leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
 \leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693
@@ -111,33 +120,33 @@ Hyperlink;}{\*\cs19 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf20\chshdng0\chcfpa
 \levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
 \levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
 \levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li6480\lin6480 }{\listname ;}\listid1940482595}{\list\listtemplateid-879616424\listhybrid{\listlevel\levelnfc23\levelnfcn23
-\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
-\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
-\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360
-\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0
-{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693
-\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li6480\lin6480 }{\listname ;}\listid2002729840}{\list\listtemplateid-1055998564\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360
-\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0
-{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li6480\lin6480 }{\listname ;}\listid2008631076}}{\*\listoverridetable{\listoverride\listid558714133\listoverridecount0\ls1}{\listoverride\listid676005662
-\listoverridecount0\ls2}{\listoverride\listid1940482595\listoverridecount0\ls3}{\listoverride\listid872425844\listoverridecount0\ls4}{\listoverride\listid2008631076\listoverridecount0\ls5}{\listoverride\listid314996233\listoverridecount0\ls6}
-{\listoverride\listid1217358328\listoverridecount0\ls7}{\listoverride\listid642077380\listoverridecount0\ls8}{\listoverride\listid2002729840\listoverridecount0\ls9}}{\*\rsidtbl \rsid201962\rsid599009\rsid804820\rsid1142629\rsid1262568\rsid2246377
-\rsid2584501\rsid2585069\rsid3085909\rsid3232403\rsid3637189\rsid4090611\rsid4482658\rsid4940151\rsid4947640\rsid6963519\rsid7282308\rsid9244280\rsid9438945\rsid9646566\rsid9661052\rsid10106340\rsid10227609\rsid10382262\rsid10704264\rsid10752920
+\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1
+\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0
+{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691
+\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}
+\f10\fbias0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 
+\fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel
+\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid2002729840}
+{\list\listtemplateid-1055998564\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
+\fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
+\fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
+\fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
+\fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
+\fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
+\fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
+\fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
+\fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
+\fi-180\li6480\lin6480 }{\listname ;}\listid2008631076}}{\*\listoverridetable{\listoverride\listid558714133\listoverridecount0\ls1}{\listoverride\listid676005662\listoverridecount0\ls2}{\listoverride\listid1940482595\listoverridecount0\ls3}
+{\listoverride\listid872425844\listoverridecount0\ls4}{\listoverride\listid2008631076\listoverridecount0\ls5}{\listoverride\listid314996233\listoverridecount0\ls6}{\listoverride\listid1217358328\listoverridecount0\ls7}{\listoverride\listid642077380
+\listoverridecount0\ls8}{\listoverride\listid2002729840\listoverridecount0\ls9}{\listoverride\listid282074041\listoverridecount0\ls10}}{\*\rsidtbl \rsid201962\rsid472113\rsid599009\rsid804820\rsid1142629\rsid1262568\rsid2246377\rsid2584501\rsid2585069
+\rsid3085909\rsid3232403\rsid3637189\rsid4090611\rsid4482658\rsid4540678\rsid4940151\rsid4947640\rsid6963519\rsid7282308\rsid9244280\rsid9438945\rsid9635381\rsid9646566\rsid9661052\rsid10106340\rsid10227609\rsid10382262\rsid10704264\rsid10752920
 \rsid11218240\rsid12087820\rsid12282547\rsid12348097\rsid12615477\rsid13134628\rsid13253201\rsid13729317\rsid14370152\rsid14580330\rsid14894181\rsid15038176}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1
-\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo4\dy1\hr13\min41}{\revtim\yr2020\mo4\dy28\hr6\min53}{\version31}{\edmins109}{\nofpages9}{\nofwords2328}{\nofchars13276}{\nofcharsws15573}{\vern127}}
-{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo4\dy1\hr13\min41}{\revtim\yr2020\mo12\dy31\hr7\min32}{\version34}{\edmins126}{\nofpages9}{\nofwords2338}{\nofchars13329}{\nofcharsws15636}{\vern13}}{\*\xmlnstbl {\xmlns1 http:
+//schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale113\rsidroot14894181 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NjWyNLIwMTE1MzA1NTJU0lEKTi0uzszPAykwqQUAWhfTDywAAAA=}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot14894181 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NjWyNLIwMTE1MzA1NTJU0lEKTi0uzszPAykwrwUAmUT+JCwAAAA=}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
@@ -149,15 +158,14 @@ Hyperlink;}{\*\cs19 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf20\chshdng0\chcfpa
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Before we can start using PowerShell to }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15038176 \hich\af37\dbch\af31505\loch\f37 assess a}{\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37  PVS farm, let us ensure we have the necessary requirements.
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid9244280 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard\plain \ltrpar\s17\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault\faauto\ls9\rin0\lin720\itap0\pararsid9244280 
-\rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid9244280 \hich\af31506\dbch\af31505\loch\f31506 Install }{
-\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 the PVS Console PowerShell.
-\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \ab\af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid10382262\charrsid9244280 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard\plain \ltrpar\ql \fi-360\li720\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls9\rin0\lin720\itap0\pararsid9244280 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid10382262\charrsid9244280 \hich\af37\dbch\af31505\loch\f37 The account used to run this script must have at least Read access to the SQL Server that holds the Citrix Provisioning databases.}{\rtlch\fcs1 \ab\af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid10382262 
-\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \ab\af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid10106340 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}{\rtlch\fcs1 \ab\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10106340 \hich\af37\dbch\af31505\loch\f37 
-The script requires an elevated PowerShell session.}{\rtlch\fcs1 \ab\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10106340\charrsid9244280 
+\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid9244280\charrsid9635381 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault\faauto\ls10\rin0\lin720\itap0\pararsid9635381 {
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f31506\fs22\insrsid9244280\charrsid9635381 \hich\af31506\dbch\af31505\loch\f31506 Install }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid9635381 \hich\af31506\dbch\af31505\loch\f31506 
+the PVS Console PowerShell.
+\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \ab\af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid9635381\charrsid9635381 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}{\rtlch\fcs1 \ab\af37\afs22 \ltrch\fcs0 \f31506\fs22\insrsid9635381\charrsid9635381 
+\hich\af31506\dbch\af31505\loch\f31506 T}{\rtlch\fcs1 \ab\af37\afs22 \ltrch\fcs0 \f31506\fs22\insrsid10382262\charrsid9635381 \hich\af31506\dbch\af31505\loch\f31506 he account used to run t\hich\af31506\dbch\af31505\loch\f31506 
+his script must have at least Read access to the SQL Server that holds the Citrix Provisioning databases.}{\rtlch\fcs1 \ab\af37\afs22 \ltrch\fcs0 \f31506\fs22\insrsid9635381\charrsid9635381 
+\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \ab\af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid10106340\charrsid9635381 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}{\rtlch\fcs1 \ab\af37\afs22 \ltrch\fcs0 \f31506\fs22\insrsid10106340\charrsid9635381 
+\hich\af31506\dbch\af31505\loch\f31506 The script requires an elevated PowerShell session.
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid10382262 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
 \rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid15038176 \page }{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid2585069 \hich\af43\dbch\af31505\loch\f43 Script Usage
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
@@ -175,10 +183,10 @@ From the PowerShell prompt, change to your PowerShell scripts.
 \ai\af0\afs22 \ltrch\fcs0 \i\f31506\fs22\insrsid9244280 \hich\af31506\dbch\af31505\loch\f31506 HealthCheck}{\rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \i\f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 .ps1}{\rtlch\fcs1 
 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506  and press }{\rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \i\f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 Enter}{
 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 .}{\rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \i\f31506\fs22\insrsid2585069\charrsid13253201 
-\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 4.\tab}}\pard \ltrpar
-\ql \fi-720\li1080\ri0\nowidctlpar\wrapdefault\faauto\ls7\rin0\lin1080\itap0\pararsid14894181 {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 By default, a }{\rtlch\fcs1 \af0\afs22 
-\ltrch\fcs0 \f31506\fs22\insrsid15038176 \hich\af31506\dbch\af31505\loch\f31506 text file}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506  is cr\hich\af31506\dbch\af31505\loch\f31506 
-eated named after the PVS Farm.}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069 
+\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid9635381 \hich\af31506\dbch\af31505\loch\f31506 4.\tab}}\pard \ltrpar\ql \fi-720\li1080\ri0\nowidctlpar\wrapdefault\faauto\ls7\rin0\lin1080\itap0\pararsid14894181 {
+\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid9635381 \hich\af31506\dbch\af31505\loch\f31506 The script creates a}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506  }{
+\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid15038176 \hich\af31506\dbch\af31505\loch\f31506 text file}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 
+ named after the PVS Farm.}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069 
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid15038176 \hich\af31506\dbch\af31505\loch\f31506 5.\tab}}\pard \ltrpar\ql \fi-720\li1080\ri0\nowidctlpar\wrapdefault\faauto\ls7\rin0\lin1080\itap0\pararsid15038176 {
 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid15038176 \hich\af31506\dbch\af31505\loch\f31506 This script is designed to be run directly on a PVS server since only a text file is created. 
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid15038176 \hich\af31506\dbch\af31505\loch\f31506 6.\tab}\hich\af31506\dbch\af31505\loch\f31506 Word is not used or required.}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 
@@ -186,37 +194,34 @@ eated named after the PVS Farm.}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22
 \par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15038176 
 \par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 \hich\af37\dbch\af31505\loch\f37 To run the script remotely, please read the following article}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 \hich\af37\dbch\af31505\loch\f37 
 s}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 \hich\af37\dbch\af31505\loch\f37 :
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181\charrsid14894181 \hich\af37\dbch\af31505\loch\f37 
-http://carlwebster.com/using-my-citrix-pvs-powershell-documentation-script-with-remoting/}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 \hich\af37\dbch\af31505\loch\f37 " }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid13253201 
-{\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bcc00000068007400740070003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f007500730069006e0067002d006d0079002d006300690074007200690078002d0070007600
-73002d0070006f007700650072007300680065006c006c002d0064006f00630075006d0065006e0074006100740069006f006e002d007300630072006900700074002d0077006900740068002d00720065006d006f00740069006e0067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00000075000073
-00000000000000000058632ef0005600000092c108}}}{\fldrslt {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid14894181\charrsid7282308 \hich\af37\dbch\af31505\loch\f37 
-http://carlwebster.com/using-my-citrix-pvs-powershell-documentation-script-with-remoting/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547\charrsid12282547 \hich\af37\dbch\af31505\loch\f37 
-http://carlwebster.com/pvs-v2-documentation-script-has-been-updated-17-jun-2013/}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 \hich\af37\dbch\af31505\loch\f37 " }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid4090611 
-{\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bba00000068007400740070003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f007000760073002d00760032002d0064006f00630075006d0065006e007400610074006900
-6f006e002d007300630072006900700074002d006800610073002d006200650065006e002d0075007000640061007400650064002d00310037002d006a0075006e002d0032003000310033002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000000334500000000008000ff455872746300009c734dfd7f
-00}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid12282547\charrsid11218240 \hich\af37\dbch\af31505\loch\f37 http://carlwebster.com/pvs-v2-documentation-script-has-been-updated-17-jun-2013/}}}\sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547\charrsid12282547 \hich\af37\dbch\af31505\loch\f37 
-http://carlwebster.com/error-in-the-provisioning-services\hich\af37\dbch\af31505\loch\f37 -7-0-powershell-programmer-guide-for-windows-8-and-server-2012/}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 \hich\af37\dbch\af31505\loch\f37 " }{
-\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid4090611 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b0a01000068007400740070003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f006500720072006f0072002d0069006e002d007400680065002d00700072006f0076006900
-730069006f006e0069006e0067002d00730065007200760069006300650073002d0037002d0030002d0070006f007700650072007300680065006c006c002d00700072006f006700720061006d006d00650072002d00670075006900640065002d0066006f0072002d00770069006e0064006f00770073002d0038002d0061
-006e0064002d007300650072007600650072002d0032003000310032002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00000000000000000000806300005f30c0630065007400fd7f00}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\cs18\f37\fs22\ul\cf19\insrsid12282547\charrsid11218240 \hich\af37\dbch\af31505\loch\f37 http://carlwebster.com/error-in-the-provisioning-services-7-0-powershell-programmer-guide-for-windows-8-and-server-2012/}}}\sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 
+\par }{\field\fldedit{\*\fldinst {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid472113 \hich\af37\dbch\af31505\loch\f37 HYPERLINK \hich\af37\dbch\af31505\loch\f37 
+"https://carlwebster.com/using-my-citrix-pvs-powershell-documentation-script-with-remoting/"}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid472113 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bce000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f007500730069006e0067002d006d0079002d006300690074007200690078002d007000
+760073002d0070006f007700650072007300680065006c006c002d0064006f00630075006d0065006e0074006100740069006f006e002d007300630072006900700074002d0077006900740068002d00720065006d006f00740069006e0067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}
+}{\fldrslt {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid472113 \hich\af37\dbch\af31505\loch\f37 https://carlwebster.com/using-my-citrix-pvs-powershell-documentation-script-with-remoting/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 
+\par }{\field\fldedit{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid472113 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "https://carlwebster.com/pvs-v2-documentation-script-has-been-updated-17-jun-2013/"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid472113 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bbc000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f007000760073002d00760032002d0064006f00630075006d0065006e00740061007400
+69006f006e002d007300630072006900700074002d006800610073002d006200650065006e002d0075007000640061007400650064002d00310037002d006a0075006e002d0032003000310033002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
+\ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid472113 \hich\af37\dbch\af31505\loch\f37 htt\hich\af37\dbch\af31505\loch\f37 ps://carlwebster.com/pvs-v2-documentation-script-has-been-updated-17-jun-2013/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 
+\par }{\field\fldedit{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid472113 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "https://carlwebster.com/error-in-the-provisioning-servic\hich\af37\dbch\af31505\loch\f37 
+es-7-0-powershell-programmer-guide-for-windows-8-and-server-2012/"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid472113 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b0c010000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f006500720072006f0072002d0069006e002d007400680065002d00700072006f007600
+6900730069006f006e0069006e0067002d00730065007200760069006300650073002d0037002d0030002d0070006f007700650072007300680065006c006c002d00700072006f006700720061006d006d00650072002d00670075006900640065002d0066006f0072002d00770069006e0064006f00770073002d0038002d
+0061006e0064002d007300650072007600650072002d0032003000310032002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid472113 \hich\af37\dbch\af31505\loch\f37 
+https://carlwebster.com/error-in-the-provisioning-services-7-0-powershell-programmer-guide-for-windows-8-and-server-2012/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 
 \par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Full help text is available.
 \par }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Get-Help .\\PVS_}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9244280 \hich\af37\dbch\af31505\loch\f37 HealthCheck}{\rtlch\fcs1 
-\ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid15038176 .}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 ps1 \hich\f37 \endash \loch\f37 full
-\par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 The help text explai\hich\af37\dbch\af31505\loch\f37 ns all the parameters the script accepts.
-\par \hich\af37\dbch\af31505\loch\f37 I have tested this script with PVS 5.6 SP3}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9646566 \hich\af37\dbch\af31505\loch\f37  through 1903}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 
-\hich\af37\dbch\af31505\loch\f37 . I have tested the script running on and from Windows 7, Windows 8}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid4090611 \hich\af37\dbch\af31505\loch\f37 .x}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 , }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9646566 \hich\af37\dbch\af31505\loch\f37 Windows 10, }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 
-\hich\af37\dbch\af31505\loch\f37 Server 2003 R2, Server 2008 R2, Server 2012}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9646566 \hich\af37\dbch\af31505\loch\f37 , }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 
-\hich\af37\dbch\af31505\loch\f37 Server 2012 R2}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9646566 \hich\af37\dbch\af31505\loch\f37 , and Server 2016}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 .
+\ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid15038176 .}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 ps1 \hich\f37 \endash \loch\f37 f\hich\af37\dbch\af31505\loch\f37 ull
+\par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 The help text explains all the parameters the script accepts.
+\par \hich\af37\dbch\af31505\loch\f37 I have tested this script with PVS 5.6 SP3}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9646566 \hich\af37\dbch\af31505\loch\f37  through }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9635381 
+\hich\af37\dbch\af31505\loch\f37 2012}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 . I have tested the script running on and from Windows 7, Windows 8}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid4090611 \hich\af37\dbch\af31505\loch\f37 .x}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 , }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9646566 \hich\af37\dbch\af31505\loch\f37 
+Windows 10, }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Server 2003 R2, Server 2008 R2, Server 2012}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9646566 \hich\af37\dbch\af31505\loch\f37 , }{
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Server \hich\af37\dbch\af31505\loch\f37 2012 R2}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9646566 \hich\af37\dbch\af31505\loch\f37 , Server 2016}{
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9635381 \hich\af37\dbch\af31505\loch\f37 , and Server 2019}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 .
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid10382262 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
 \rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid13134628 \page \hich\af43\dbch\af31505\loch\f43 Help }{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid13134628\charrsid10382262 \hich\af43\dbch\af31505\loch\f43 Text}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid13134628 
 \par }\pard\plain \ltrpar\s17\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid13134628 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 
@@ -229,14 +234,13 @@ http://carlwebster.com/error-in-the-provisioning-services\hich\af37\dbch\af31505
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNTAX
-\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\PVS_HealthCheck.ps1 [[-AdminAddress] <String>] [-CSV] [-Dev] [[-Domain] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 <String>] [[-Folder] <S\hich\af2\dbch\af31505\loch\f2 tring>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid9244280 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 [-Log] [[-Password] <String>] [-ScriptInfo] [[-User] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid9244280 
+\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\\hich\af2\dbch\af31505\loch\f2 PVS_HealthCheck.ps1 [[-AdminAddress] <String>] [-CSV] [-Dev] [[-Domain] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 <String>] [[-Folder] <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 [-Log] <String>] [-ScriptInfo] [[-User] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 <String>] [[-SmtpServer] <String>] [[-SmtpPort] <Int32>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid9244280 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 [-UseSSL] [[-From] <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 
 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 [[-To] <String>] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 [[-To] <Stri\hich\af2\dbch\af31505\loch\f2 ng>] [<CommonParameters>]
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
@@ -245,7 +249,7 @@ http://carlwebster.com/error-in-the-provisioning-services\hich\af37\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     Creates a text document named after the PVS farm.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     NOTE: The account used to run this script must have at least Read access to the SQL
-\par \hich\af2\dbch\af31505\loch\f2     Server that holds the Citrix Provisionin\hich\af2\dbch\af31505\loch\f2 g databases.
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 Server that holds the Citrix Provisioning databases.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 PARAMETERS
@@ -256,54 +260,64 @@ http://carlwebster.com/error-in-the-provisioning-services\hich\af37\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of AA
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Position?                    1
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    1
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -CSV [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -CSV [<SwitchParam\hich\af2\dbch\af31505\loch\f2 eter>]
 \par \hich\af2\dbch\af31505\loch\f2         Will create a CSV file for each Appendix.
-\par \hich\af2\dbch\af31505\loch\f2         The default value is F\hich\af2\dbch\af31505\loch\f2 alse.
+\par \hich\af2\dbch\af31505\loch\f2         The default value is False.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Output CSV filename is in the format:
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         PVSFarmName_HealthCheck_Appendix#_NameOfAppendix.csv
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         For example:
-\par \hich\af2\dbch\af31505\loch\f2                 TNPVSFarm_HealthCheck_AppendixA_AdvancedServerItems1.csv
-\par \hich\af2\dbch\af31505\loch\f2                 TNPVSFarm_HealthCheck_Appendix\hich\af2\dbch\af31505\loch\f2 B_AdvancedServerItems2.csv
+\par \hich\af2\dbch\af31505\loch\f2                 TNPVSFarm_Health\hich\af2\dbch\af31505\loch\f2 Check_AppendixA_AdvancedServerItems1.csv
+\par \hich\af2\dbch\af31505\loch\f2                 TNPVSFarm_HealthCheck_AppendixB_AdvancedServerItems2.csv
 \par \hich\af2\dbch\af31505\loch\f2                 TNPVSFarm_HealthCheck_AppendixC_ConfigWizardItems.csv
 \par \hich\af2\dbch\af31505\loch\f2                 TNPVSFarm_HealthCheck_AppendixD_ServerBootstrapItems.csv
 \par \hich\af2\dbch\af31505\loch\f2                 TNPVSFarm_HealthCheck_AppendixE_DisableTaskOffloadSetting.csv
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2         TNPVSFarm_HealthCheck_AppendixF_PVSServices.csv
+\par \hich\af2\dbch\af31505\loch\f2                 TNPVSFarm_HealthCheck_AppendixF_PVSServices.csv
 \par \hich\af2\dbch\af31505\loch\f2                 TNPVSFarm_HealthCheck_AppendixG_vDiskstoMerge.csv
-\par \hich\af2\dbch\af31505\loch\f2                 TNPVSFarm_HealthCheck_AppendixH_EmptyDeviceCollections.csv
+\par \hich\af2\dbch\af31505\loch\f2                 TNPVSFarm_HealthCheck_AppendixH\hich\af2\dbch\af31505\loch\f2 _EmptyDeviceCollections.csv
 \par \hich\af2\dbch\af31505\loch\f2                 TNPVSFarm_HealthCheck_AppendixI_UnassociatedvDisks.csv
 \par \hich\af2\dbch\af31505\loch\f2                 TNPVSFarm_HealthCheck_AppendixJ_BadStreamingIPAddresses.csv
-\par \hich\af2\dbch\af31505\loch\f2                 TNPVSFarm_HealthCh\hich\af2\dbch\af31505\loch\f2 eck_AppendixK_MiscRegistryItems.csv
-\par \hich\af2\dbch\af31505\loch\f2                 TNPVSFarm_HealthCheck_AppendixL_vDisksConfiguredforServerSideCaching.csv
+\par \hich\af2\dbch\af31505\loch\f2                 TNPVSFarm_HealthCh\hich\af2\dbch\af31505\loch\f2 eck_AppendixK_MiscRegistryItems.csv                }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4540678 \hich\af2\dbch\af31505\loch\f2            }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 TNPVSFarm_HealthCheck_AppendixL_vDisksConfiguredforServerSideCaching.csv
 \par \hich\af2\dbch\af31505\loch\f2                 TNPVSFarm_HealthCheck_AppendixM_MicrosoftHotfixesandUpdates.csv
-\par \hich\af2\dbch\af31505\loch\f2                 TNPVSFarm_HealthCheck_AppendixN_Ins\hich\af2\dbch\af31505\loch\f2 talledRolesandFeatures.csv
+\par \hich\af2\dbch\af31505\loch\f2                 TNPVSFarm_HealthCheck_App\hich\af2\dbch\af31505\loch\f2 endixN_InstalledRolesandFeatures.csv
 \par \hich\af2\dbch\af31505\loch\f2                 TNPVSFarm_HealthCheck_AppendixO_PVSProcesses.csv
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par }\pard \ltrpar\s17\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid4540678 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4540678\charrsid4540678 \tab \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4540678 
+\hich\af2\dbch\af31505\loch\f2   }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4540678\charrsid4540678 \hich\af2\dbch\af31505\loch\f2 TNPVSFarm_HealthCheck_AppendixP_ItemsToReview.csv
+\par \tab \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4540678 \hich\af2\dbch\af31505\loch\f2   }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4540678\charrsid4540678 \hich\af2\dbch\af31505\loch\f2 
+TNPVSFarm_HealthCheck_AppendixQ_ServerComputerItemsToReview.csv
+\par \tab \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4540678 \hich\af2\dbch\af31505\loch\f2   }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4540678\charrsid4540678 \hich\af2\dbch\af31505\loch\f2 TNPVSFarm_HealthCheck_Append
+\hich\af2\dbch\af31505\loch\f2 ixQ_ServerDriveItemsToReview.csv
+\par \tab \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4540678 \hich\af2\dbch\af31505\loch\f2   }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4540678\charrsid4540678 \hich\af2\dbch\af31505\loch\f2 
+TNPVSFarm_HealthCheck_AppendixQ_ServerProcessorItemsToReview.csv
+\par \tab \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4540678 \hich\af2\dbch\af31505\loch\f2   }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4540678\charrsid4540678 \hich\af2\dbch\af31505\loch\f2 
+TNPVSFarm_HealthCheck_AppendixQ_ServerNICItemsToReview.csv}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4540678\charrsid9244280 
+\par }\pard \ltrpar\s17\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid9244280 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?    \hich\af2\dbch\af31505\loch\f2    false
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
-\par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
+\par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at th\hich\af2\dbch\af31505\loch\f2 e end of the script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requ\hich\af2\dbch\af31505\loch\f2 ests more troubleshooting data.
+\par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
 \par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script is run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?    \hich\af2\dbch\af31505\loch\f2                 false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -334,32 +348,23 @@ http://carlwebster.com/error-in-the-provisioning-services\hich\af37\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Password <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the password used for the AdminAddress connection.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    4
-\par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  fa\hich\af2\dbch\af31505\loch\f2 lse
-\par 
 \par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a text file.
 \par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script is run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter ha\hich\af2\dbch\af31505\loch\f2 s an alias of SI.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    nam\hich\af2\dbch\af31505\loch\f2 ed
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -User <String>
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Specifies the user used for the AdminAddress connection.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the user used for the AdminAddress connection.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    f\hich\af2\dbch\af31505\loch\f2 alse
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    5
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -368,28 +373,28 @@ http://carlwebster.com/error-in-the-provisioning-services\hich\af37\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    6
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Acce\hich\af2\dbch\af31505\loch\f2 pt wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port.
+\par \hich\af2\dbch\af31505\loch\f2         Spec\hich\af2\dbch\af31505\loch\f2 ifies the SMTP port.
 \par \hich\af2\dbch\af31505\loch\f2         The default port is 25.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    7
 \par \hich\af2\dbch\af31505\loch\f2         Default value                25
-\par \hich\af2\dbch\af31505\loch\f2         Accept\hich\af2\dbch\af31505\loch\f2  pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  \hich\af2\dbch\af31505\loch\f2 false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServer.
 \par \hich\af2\dbch\af31505\loch\f2         THe default is False.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?   \hich\af2\dbch\af31505\loch\f2                  named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -398,10 +403,10 @@ http://carlwebster.com/error-in-the-provisioning-services\hich\af37\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?            \hich\af2\dbch\af31505\loch\f2         false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    8
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input? \hich\af2\dbch\af31505\loch\f2       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -To <String>
@@ -409,33 +414,38 @@ http://carlwebster.com/error-in-the-provisioning-services\hich\af37\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?    \hich\af2\dbch\af31505\loch\f2                 9
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    9
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?   \hich\af2\dbch\af31505\loch\f2     false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
 \par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
-\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, Wa\hich\af2\dbch\af31505\loch\f2 rningAction, WarningVariable,
-\par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
-\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216).
+\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
+\par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and Ou\hich\af2\dbch\af31505\loch\f2 tVariable. For more information, see
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid472113 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
+HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid472113 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid9244280\charrsid472113 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216}}}
+\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
 \par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to this script.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
-\par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.  This script creates a text file.
+\par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.  This script creates a tex\hich\af2\dbch\af31505\loch\f2 t file.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: PVS_HealthCheck.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 1.22
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 1.2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9635381 \hich\af2\dbch\af31505\loch\f2 3}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster (with a lot of help from BG a, now former, Citrix dev)
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: Ap\hich\af2\dbch\af31505\loch\f2 ril 2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid804820 \hich\af2\dbch\af31505\loch\f2 8}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 , 2020
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9635381 \hich\af2\dbch\af31505\loch\f2 December }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4540678 \hich\af2\dbch\af31505\loch\f2 3}{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid472113 \hich\af2\dbch\af31505\loch\f2 1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9635381 \hich\af2\dbch\af31505\loch\f2 , 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid9244280\charrsid9244280 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
@@ -449,8 +459,8 @@ http://carlwebster.com/error-in-the-provisioning-services\hich\af37\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 2 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_HealthCheck.ps1 -AdminAddress PVS1 -User cwebster -Domain }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10106340 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 WebstersLab -Password Abc123!@#
+\par \hich\af2\dbch\af31505\loch\f2     PS\hich\af2\dbch\af31505\loch\f2  C:\\PSScript >.\\PVS_HealthCheck.ps1 -AdminAddress PVS1 -User cwebster -Domain }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10106340 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 WebstersLab
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This example is usually used to run the script against a PVS Farm in
 \par \hich\af2\dbch\af31505\loch\f2     another domain or forest.
@@ -459,26 +469,24 @@ http://carlwebster.com/error-in-the-provisioning-services\hich\af37\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2         PVS1 for AdminAddress.
 \par \hich\af2\dbch\af31505\loch\f2         cwebster for User.
 \par \hich\af2\dbch\af31505\loch\f2         WebstersLab for Domain.
-\par \hich\af2\dbch\af31505\loch\f2         Abc123!@# for Password.
+\par \hich\af2\dbch\af31505\loch\f2         
 \par 
 \par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 3 --------------------------
 \par 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     --------\hich\af2\dbch\af31505\loch\f2 ------------------ EXAMPLE 3 --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_HealthCheck.ps1 -AdminAddress PVS1 -User cwebster
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 PVS_HealthCheck.ps1 -AdminAddress PVS1 -User cwebster
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         PVS1 for AdminAddress.
 \par \hich\af2\dbch\af31505\loch\f2         cwebster for User.
-\par \hich\af2\dbch\af31505\loch\f2         Script will prompt for the Domain and Pass\hich\af2\dbch\af31505\loch\f2 word
+\par \hich\af2\dbch\af31505\loch\f2         Script will prompt for the Domain and Password
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 4 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_HealthCheck.ps1 -Folder \\\\FileServer\\ShareName
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    PS C:\\PSScript >.\\PVS_HealthCheck.ps1 -Folder \\\\FileServer\\ShareName
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Output file will be saved in the path \\\\FileServer\\ShareName
 \par 
@@ -487,11 +495,11 @@ http://carlwebster.com/error-in-the-provisioning-services\hich\af37\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 5 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_HealthCheck.ps1 -SmtpServer mail.domain.tld -From
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_HealthCheck.ps1 -Sm\hich\af2\dbch\af31505\loch\f2 tpServer mail.domain.tld -From
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     XDAdmin@domain.tld -To ITGroup@domain.tld -ComputerName DHCPServer01
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Script will use the email server\hich\af2\dbch\af31505\loch\f2  mail.domain.tld, sending from XDAdmin@domain.tld,
+\par \hich\af2\dbch\af31505\loch\f2     Script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld,
 \par \hich\af2\dbch\af31505\loch\f2     sending to ITGroup@domain.tld.
 \par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be prompted
 \par \hich\af2\dbch\af31505\loch\f2     to enter valid credentials.
@@ -499,18 +507,18 @@ http://carlwebster.com/error-in-the-provisioning-services\hich\af37\dbch\af31505
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 6 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -\hich\af2\dbch\af31505\loch\f2 ------------------------- EXAMPLE 6 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_HealthCheck.ps1 -Dev -ScriptInfo -Log
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a text file named PVSHealthCheckScriptErrors_yyyy-MM-dd_HHmm.txt that
-\par \hich\af2\dbch\af31505\loch\f2     contains up to the last 250 errors reported by the script.
+\par \hich\af2\dbch\af31505\loch\f2     contains up to the last 250 errors report\hich\af2\dbch\af31505\loch\f2 ed by the script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a tex\hich\af2\dbch\af31505\loch\f2 t file named PVSHealthCheckScriptInfo_yyyy-MM-dd_HHmm.txt that
+\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named PVSHealthCheckScriptInfo_yyyy-MM-dd_HHmm.txt that
 \par \hich\af2\dbch\af31505\loch\f2     contains all the script parameters and other basic information.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a text file for transcript logging named
-\par \hich\af2\dbch\af31505\loch\f2     PVSHealthCheckScriptTranscript_yyyy-MM-dd_HHmm.txt.
+\par \hich\af2\dbch\af31505\loch\f2     PVSHealthCheckScriptTranscript_\hich\af2\dbch\af31505\loch\f2 yyyy-MM-dd_HHmm.txt.
 \par 
 \par 
 \par 
@@ -521,7 +529,7 @@ http://carlwebster.com/error-in-the-provisioning-services\hich\af37\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     LocalHost for AdminAddress.
-\par \hich\af2\dbch\af31505\loch\f2     Creates a \hich\af2\dbch\af31505\loch\f2 CSV file for each Appendix.
+\par \hich\af2\dbch\af31505\loch\f2     Crea\hich\af2\dbch\af31505\loch\f2 tes a CSV file for each Appendix.
 \par 
 \par 
 \par 
@@ -533,13 +541,13 @@ http://carlwebster.com/error-in-the-provisioning-services\hich\af37\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     -From XDAdmin@domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@domain.tld
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use \hich\af2\dbch\af31505\loch\f2 the email server mail.domain.tld, sending from XDAdmin@domain.tld,
+\par \hich\af2\dbch\af31505\loch\f2     The script wil\hich\af2\dbch\af31505\loch\f2 l use the email server mail.domain.tld, sending from XDAdmin@domain.tld,
 \par \hich\af2\dbch\af31505\loch\f2     sending to ITGroup@domain.tld.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will not use SSL.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
-\par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
+\par \hich\af2\dbch\af31505\loch\f2     the \hich\af2\dbch\af31505\loch\f2 user will be prompted to enter valid credentials.
 \par 
 \par 
 \par 
@@ -549,14 +557,14 @@ http://carlwebster.com/error-in-the-provisioning-services\hich\af37\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_HealthCheck.ps1
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer mailrelay.domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     -From Anonymous@domain.tld
-\par \hich\af2\dbch\af31505\loch\f2     -To ITGroup\hich\af2\dbch\af31505\loch\f2 @domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@domain.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***SENDING UNAUTHENTICATED EMAIL***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the email server mailrelay.domain.tld, sending from
 \par \hich\af2\dbch\af31505\loch\f2     anonymous@domain.tld, sending to ITGroup@domain.tld.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     To send unauthenticated email using an email relay server requir\hich\af2\dbch\af31505\loch\f2 es the From email account
+\par \hich\af2\dbch\af31505\loch\f2     To send unauthenticated email using an email rela\hich\af2\dbch\af31505\loch\f2 y server requires the From email account
 \par \hich\af2\dbch\af31505\loch\f2     to use the name Anonymous.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will not use SSL.
@@ -565,16 +573,16 @@ http://carlwebster.com/error-in-the-provisioning-services\hich\af37\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid9244280 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00039f12e7}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00039f12e7000051}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid9244280 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030020b0}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030020b0000000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail or g-suite account, you may have to turn ON
-\par \hich\af2\dbch\af31505\loch\f2     the "Less secure app access" option on your\hich\af2\dbch\af31505\loch\f2  account.
+\par \hich\af2\dbch\af31505\loch\f2     the "Less secure app ac\hich\af2\dbch\af31505\loch\f2 cess" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will generate an anonymous secure password for the anonymous@domain.tld
@@ -589,26 +597,27 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer labaddomain-com.mail.protection.outlook.com
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL
 \par \hich\af2\dbch\af31505\loch\f2     -From SomeEmailAddress@labaddomain.com
-\par \hich\af2\dbch\af31505\loch\f2     -To ITGroupDL@labaddomain\hich\af2\dbch\af31505\loch\f2 .com
+\par \hich\af2\dbch\af31505\loch\f2     -To ITGroupDL@labaddomain.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 \hich\af2\dbch\af31505\loch\f2 
- HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://docs.micro\hich\af2\dbch\af31505\loch\f2 
+soft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900660075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab0003010000}}}{\fldrslt {\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifun\hich\af2\dbch\af31505\loch\f2 
-ction-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab0003010000000000}}}{\fldrslt {
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 
+https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid9244280\charrsid9244280 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
+\par \hich\af2\dbch\af31505\loch\f2     Thi\hich\af2\dbch\af31505\loch\f2 s uses Option 2 from the above link.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the email server labaddomain-com.mail.protection.outlook.com,
-\par \hich\af2\dbch\af31505\loch\f2     sending from SomeEmailAddress@\hich\af2\dbch\af31505\loch\f2 labaddomain.com, sending to ITGroupDL@labaddomain.com.
+\par \hich\af2\dbch\af31505\loch\f2     sending from SomeEmailAddress@labaddomain.com, sending to ITGroupDL@labaddomain.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will use SSL.
+\par \hich\af2\dbch\af31505\loch\f2     The scri\hich\af2\dbch\af31505\loch\f2 pt will use the default SMTP port 25 and will use SSL.
 \par 
 \par 
 \par 
@@ -619,14 +628,14 @@ ction-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer smtp.office365.com
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort 587
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL
-\par \hich\af2\dbch\af31505\loch\f2     -From Webster@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     -Fr\hich\af2\dbch\af31505\loch\f2 om Webster@CarlWebster.com
 \par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@CarlWebster.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The scri\hich\af2\dbch\af31505\loch\f2 pt will use the email server smtp.office365.com on port 587 using SSL,
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp.office365.com on port 587 using SSL,
 \par \hich\af2\dbch\af31505\loch\f2     sending from webster@carlwebster.com, sending to ITGroup@carlwebster.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
-\par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter \hich\af2\dbch\af31505\loch\f2 valid credentials.
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credenti\hich\af2\dbch\af31505\loch\f2 als are not valid to send email,
+\par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
 \par 
 \par 
 \par 
@@ -638,17 +647,17 @@ ction-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort 587
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL
 \par \hich\af2\dbch\af31505\loch\f2     -From Webster@CarlWebster.com
-\par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@CarlWebste\hich\af2\dbch\af31505\loch\f2 r.com
+\par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
 \par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail or g-suite account, you may have to turn ON
 \par \hich\af2\dbch\af31505\loch\f2     the "Less secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use\hich\af2\dbch\af31505\loch\f2  the email server smtp.gmail.com on port 587 using SSL,
+\par \hich\af2\dbch\af31505\loch\f2     The s\hich\af2\dbch\af31505\loch\f2 cript will use the email server smtp.gmail.com on port 587 using SSL,
 \par \hich\af2\dbch\af31505\loch\f2     sending from webster@gmail.com, sending to ITGroup@carlwebster.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
+\par \hich\af2\dbch\af31505\loch\f2     If the cur\hich\af2\dbch\af31505\loch\f2 rent user's credentials are not valid to send email,
 \par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
 \par 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 
@@ -772,8 +781,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000202e
-77b0531dd601feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000206e
+366979dfd601feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/PVS_HealthCheck_ReadMe.rtf
+++ b/PVS_HealthCheck_ReadMe.rtf
@@ -140,13 +140,13 @@ Hyperlink;}{\*\cs19 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf20\chshdng0\chcfpa
 \fi-180\li6480\lin6480 }{\listname ;}\listid2008631076}}{\*\listoverridetable{\listoverride\listid558714133\listoverridecount0\ls1}{\listoverride\listid676005662\listoverridecount0\ls2}{\listoverride\listid1940482595\listoverridecount0\ls3}
 {\listoverride\listid872425844\listoverridecount0\ls4}{\listoverride\listid2008631076\listoverridecount0\ls5}{\listoverride\listid314996233\listoverridecount0\ls6}{\listoverride\listid1217358328\listoverridecount0\ls7}{\listoverride\listid642077380
 \listoverridecount0\ls8}{\listoverride\listid2002729840\listoverridecount0\ls9}{\listoverride\listid282074041\listoverridecount0\ls10}}{\*\rsidtbl \rsid201962\rsid472113\rsid599009\rsid804820\rsid1142629\rsid1262568\rsid2246377\rsid2584501\rsid2585069
-\rsid3085909\rsid3232403\rsid3637189\rsid4090611\rsid4482658\rsid4540678\rsid4940151\rsid4947640\rsid6963519\rsid7282308\rsid9244280\rsid9438945\rsid9635381\rsid9646566\rsid9661052\rsid10106340\rsid10227609\rsid10382262\rsid10704264\rsid10752920
-\rsid11218240\rsid12087820\rsid12282547\rsid12348097\rsid12615477\rsid13134628\rsid13253201\rsid13729317\rsid14370152\rsid14580330\rsid14894181\rsid15038176}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1
-\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo4\dy1\hr13\min41}{\revtim\yr2020\mo12\dy31\hr7\min32}{\version34}{\edmins126}{\nofpages9}{\nofwords2338}{\nofchars13329}{\nofcharsws15636}{\vern13}}{\*\xmlnstbl {\xmlns1 http:
-//schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\rsid3022886\rsid3085909\rsid3232403\rsid3637189\rsid4090611\rsid4482658\rsid4540678\rsid4940151\rsid4947640\rsid6963519\rsid7282308\rsid8924948\rsid9244280\rsid9438945\rsid9635381\rsid9646566\rsid9661052\rsid10106340\rsid10227609\rsid10382262
+\rsid10704264\rsid10752920\rsid11218240\rsid12087820\rsid12282547\rsid12348097\rsid12615477\rsid13134628\rsid13253201\rsid13729317\rsid14370152\rsid14580330\rsid14894181\rsid15038176}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1
+\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo4\dy1\hr13\min41}{\revtim\yr2021\mo1\dy8\hr5\min44}{\version36}{\edmins127}{\nofpages9}{\nofwords2338}{\nofchars13327}{\nofcharsws15634}{\vern13}}
+{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot14894181 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NjWyNLIwMTE1MzA1NTJU0lEKTi0uzszPAykwrwUAmUT+JCwAAAA=}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot14894181 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NjWyNLIwMTE1MzA1NTJU0lEKTi0uzszPAymwrAUAF2l9uiwAAAA=}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
@@ -194,34 +194,34 @@ From the PowerShell prompt, change to your PowerShell scripts.
 \par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15038176 
 \par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 \hich\af37\dbch\af31505\loch\f37 To run the script remotely, please read the following article}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 \hich\af37\dbch\af31505\loch\f37 
 s}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 \hich\af37\dbch\af31505\loch\f37 :
-\par }{\field\fldedit{\*\fldinst {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid472113 \hich\af37\dbch\af31505\loch\f37 HYPERLINK \hich\af37\dbch\af31505\loch\f37 
-"https://carlwebster.com/using-my-citrix-pvs-powershell-documentation-script-with-remoting/"}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid472113 {\*\datafield 
+\par }{\field\fldedit{\*\fldinst {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid472113 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "https://carlwebster.com/using-my-citrix-pvs-powershe\hich\af37\dbch\af31505\loch\f37 
+ll-documentation-script-with-remoting/"}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid472113 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bce000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f007500730069006e0067002d006d0079002d006300690074007200690078002d007000
-760073002d0070006f007700650072007300680065006c006c002d0064006f00630075006d0065006e0074006100740069006f006e002d007300630072006900700074002d0077006900740068002d00720065006d006f00740069006e0067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}
-}{\fldrslt {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid472113 \hich\af37\dbch\af31505\loch\f37 https://carlwebster.com/using-my-citrix-pvs-powershell-documentation-script-with-remoting/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
-\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 
+760073002d0070006f007700650072007300680065006c006c002d0064006f00630075006d0065006e0074006100740069006f006e002d007300630072006900700074002d0077006900740068002d00720065006d006f00740069006e0067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00036d65}}
+}{\fldrslt {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid472113 \hich\af37\dbch\af31505\loch\f37 https://carlwebster.com/using-my-citrix-pvs-powershell\hich\af37\dbch\af31505\loch\f37 -documentation-script-with-remoting/}}}
+\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 
 \par }{\field\fldedit{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid472113 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "https://carlwebster.com/pvs-v2-documentation-script-has-been-updated-17-jun-2013/"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid472113 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bbc000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f007000760073002d00760032002d0064006f00630075006d0065006e00740061007400
-69006f006e002d007300630072006900700074002d006800610073002d006200650065006e002d0075007000640061007400650064002d00310037002d006a0075006e002d0032003000310033002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
-\ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid472113 \hich\af37\dbch\af31505\loch\f37 htt\hich\af37\dbch\af31505\loch\f37 ps://carlwebster.com/pvs-v2-documentation-script-has-been-updated-17-jun-2013/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
-\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 
+69006f006e002d007300630072006900700074002d006800610073002d006200650065006e002d0075007000640061007400650064002d00310037002d006a0075006e002d0032003000310033002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00036900}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
+\ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid472113 \hich\af37\dbch\af31505\loch\f37 https://carlwebster.com/pvs-v2-documentation-script-has-been-updated-17-jun-2013/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid12282547 
 \par }{\field\fldedit{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid472113 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "https://carlwebster.com/error-in-the-provisioning-servic\hich\af37\dbch\af31505\loch\f37 
 es-7-0-powershell-programmer-guide-for-windows-8-and-server-2012/"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid472113 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b0c010000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f006500720072006f0072002d0069006e002d007400680065002d00700072006f007600
 6900730069006f006e0069006e0067002d00730065007200760069006300650073002d0037002d0030002d0070006f007700650072007300680065006c006c002d00700072006f006700720061006d006d00650072002d00670075006900640065002d0066006f0072002d00770069006e0064006f00770073002d0038002d
-0061006e0064002d007300650072007600650072002d0032003000310032002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid472113 \hich\af37\dbch\af31505\loch\f37 
+0061006e0064002d007300650072007600650072002d0032003000310032002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00036961}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid472113 \hich\af37\dbch\af31505\loch\f37 
 https://carlwebster.com/error-in-the-provisioning-services-7-0-powershell-programmer-guide-for-windows-8-and-server-2012/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 
 \par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Full help text is available.
 \par }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Get-Help .\\PVS_}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9244280 \hich\af37\dbch\af31505\loch\f37 HealthCheck}{\rtlch\fcs1 
-\ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid15038176 .}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 ps1 \hich\f37 \endash \loch\f37 f\hich\af37\dbch\af31505\loch\f37 ull
+\ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid15038176 .}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 ps1 \hich\f37 \endash \loch\f37 full
 \par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 The help text explains all the parameters the script accepts.
 \par \hich\af37\dbch\af31505\loch\f37 I have tested this script with PVS 5.6 SP3}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9646566 \hich\af37\dbch\af31505\loch\f37  through }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9635381 
 \hich\af37\dbch\af31505\loch\f37 2012}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 . I have tested the script running on and from Windows 7, Windows 8}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid4090611 \hich\af37\dbch\af31505\loch\f37 .x}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 , }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9646566 \hich\af37\dbch\af31505\loch\f37 
 Windows 10, }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Server 2003 R2, Server 2008 R2, Server 2012}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9646566 \hich\af37\dbch\af31505\loch\f37 , }{
-\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Server \hich\af37\dbch\af31505\loch\f37 2012 R2}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9646566 \hich\af37\dbch\af31505\loch\f37 , Server 2016}{
-\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9635381 \hich\af37\dbch\af31505\loch\f37 , and Server 2019}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 .
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Server 2012 R2}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9646566 \hich\af37\dbch\af31505\loch\f37 , Server 2016}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid9635381 \hich\af37\dbch\af31505\loch\f37 , and Server 2019}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 .
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid10382262 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
 \rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid13134628 \page \hich\af43\dbch\af31505\loch\f43 Help }{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid13134628\charrsid10382262 \hich\af43\dbch\af31505\loch\f43 Text}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid13134628 
 \par }\pard\plain \ltrpar\s17\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid13134628 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 
@@ -234,22 +234,23 @@ Windows 10, }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNTAX
-\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\\hich\af2\dbch\af31505\loch\f2 PVS_HealthCheck.ps1 [[-AdminAddress] <String>] [-CSV] [-Dev] [[-Domain] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 
+\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\PVS_HealthCheck.ps1 [[-AdminAddress] <String>] [-CSV] [-Dev] [[-Domain] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 <String>] [[-Folder] <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 [-Log] <String>] [-ScriptInfo] [[-User] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 [-Log] <Str\hich\af2\dbch\af31505\loch\f2 ing>] [-ScriptInfo] [[-User] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid9244280 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 <String>] [[-SmtpServer] <String>] [[-SmtpPort] <Int32>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid9244280 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 [-UseSSL] [[-From] <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 
 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 [[-To] <Stri\hich\af2\dbch\af31505\loch\f2 ng>] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 [[-To] <String>] [<CommonParameters>]
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
 \par \hich\af2\dbch\af31505\loch\f2     Creates a basic Health Check of a Citrix PVS 5.x or later farm.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a text document named after the PVS farm.
+\par \hich\af2\dbch\af31505\loch\f2     Create\hich\af2\dbch\af31505\loch\f2 s a text document named after the PVS farm.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     NOTE: The account used to run this script must have at least Read access to the SQL
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 Server that holds the Citrix Provisioning databases.
+\par \hich\af2\dbch\af31505\loch\f2     Server that holds the Citrix Provisioning databases.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 PARAMETERS
@@ -322,13 +323,13 @@ TNPVSFarm_HealthCheck_AppendixQ_ServerNICItemsToReview.csv}{\rtlch\fcs1 \af2\afs
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Domain <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the domain used for the AdminAddress connection.
+\par \hich\af2\dbch\af31505\loch\f2         Specif\hich\af2\dbch\af31505\loch\f2 ies the domain used for the AdminAddress connection.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    2
 \par \hich\af2\dbch\af31505\loch\f2         Default value                $env:UserDnsDomain
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildca\hich\af2\dbch\af31505\loch\f2 rd characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the output report.
@@ -336,7 +337,7 @@ TNPVSFarm_HealthCheck_AppendixQ_ServerNICItemsToReview.csv}{\rtlch\fcs1 \af2\afs
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    3
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeli\hich\af2\dbch\af31505\loch\f2 ne input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?     \hich\af2\dbch\af31505\loch\f2   false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Log [<SwitchParameter>]
@@ -344,7 +345,7 @@ TNPVSFarm_HealthCheck_AppendixQ_ServerNICItemsToReview.csv}{\rtlch\fcs1 \af2\afs
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value   \hich\af2\dbch\af31505\loch\f2              False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                F\hich\af2\dbch\af31505\loch\f2 alse
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -380,14 +381,14 @@ TNPVSFarm_HealthCheck_AppendixQ_ServerNICItemsToReview.csv}{\rtlch\fcs1 \af2\afs
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
-\par \hich\af2\dbch\af31505\loch\f2         Spec\hich\af2\dbch\af31505\loch\f2 ifies the SMTP port.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port.
 \par \hich\af2\dbch\af31505\loch\f2         The default port is 25.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    7
 \par \hich\af2\dbch\af31505\loch\f2         Default value                25
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  \hich\af2\dbch\af31505\loch\f2 false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard c\hich\af2\dbch\af31505\loch\f2 haracters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServer.
@@ -395,7 +396,7 @@ TNPVSFarm_HealthCheck_AppendixQ_ServerNICItemsToReview.csv}{\rtlch\fcs1 \af2\afs
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value          \hich\af2\dbch\af31505\loch\f2       False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -403,7 +404,7 @@ TNPVSFarm_HealthCheck_AppendixQ_ServerNICItemsToReview.csv}{\rtlch\fcs1 \af2\afs
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?            \hich\af2\dbch\af31505\loch\f2         false
+\par \hich\af2\dbch\af31505\loch\f2         Required?\hich\af2\dbch\af31505\loch\f2                     false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    8
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -423,18 +424,18 @@ TNPVSFarm_HealthCheck_AppendixQ_ServerNICItemsToReview.csv}{\rtlch\fcs1 \af2\afs
 \par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
 \par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
 \par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and Ou\hich\af2\dbch\af31505\loch\f2 tVariable. For more information, see
-\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid472113 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
-HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid472113 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid472113 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid472113 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
-310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid9244280\charrsid472113 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216}}}
-\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 ).
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab00030039}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid9244280\charrsid472113 \hich\af2\dbch\af31505\loch\f2 https:/g\hich\af2\dbch\af31505\loch\f2 
+o.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
 \par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to this script.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
-\par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.  This script creates a tex\hich\af2\dbch\af31505\loch\f2 t file.
+\par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.  This script creates a text file.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
@@ -443,9 +444,8 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2         NAME: PVS_HealthCheck.ps1
 \par \hich\af2\dbch\af31505\loch\f2         VERSION: 1.2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9635381 \hich\af2\dbch\af31505\loch\f2 3}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster (with a lot of help from BG a, now former, Citrix dev)
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9635381 \hich\af2\dbch\af31505\loch\f2 December }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4540678 \hich\af2\dbch\af31505\loch\f2 3}{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid472113 \hich\af2\dbch\af31505\loch\f2 1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9635381 \hich\af2\dbch\af31505\loch\f2 , 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid9244280\charrsid9244280 
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3022886 \hich\af2\dbch\af31505\loch\f2 January }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8924948 \hich\af2\dbch\af31505\loch\f2 8}{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3022886 \hich\af2\dbch\af31505\loch\f2 , 2021}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
@@ -467,14 +467,14 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         PVS1 for AdminAddress.
-\par \hich\af2\dbch\af31505\loch\f2         cwebster for User.
+\par \hich\af2\dbch\af31505\loch\f2         cwe\hich\af2\dbch\af31505\loch\f2 bster for User.
 \par \hich\af2\dbch\af31505\loch\f2         WebstersLab for Domain.
 \par \hich\af2\dbch\af31505\loch\f2         
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 3 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 PVS_HealthCheck.ps1 -AdminAddress PVS1 -User cwebster
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_HealthCheck.ps1 -AdminAddress PVS1 -User cwebster
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         PVS1 for AdminAddress.
@@ -486,7 +486,7 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 4 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    PS C:\\PSScript >.\\PVS_HealthCheck.ps1 -Folder \\\\FileServer\\ShareName
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_HealthCheck.ps1 -Folder \\\\FileServer\\ShareNa\hich\af2\dbch\af31505\loch\f2 me
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Output file will be saved in the path \\\\FileServer\\ShareName
 \par 
@@ -495,30 +495,30 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 5 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_HealthCheck.ps1 -Sm\hich\af2\dbch\af31505\loch\f2 tpServer mail.domain.tld -From
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_HealthCheck.ps1 -SmtpServer mail.domain.tld -From
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     XDAdmin@domain.tld -To ITGroup@domain.tld -ComputerName DHCPServer01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld,
 \par \hich\af2\dbch\af31505\loch\f2     sending to ITGroup@domain.tld.
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be prompted
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send \hich\af2\dbch\af31505\loch\f2 email, the user will be prompted
 \par \hich\af2\dbch\af31505\loch\f2     to enter valid credentials.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -\hich\af2\dbch\af31505\loch\f2 ------------------------- EXAMPLE 6 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 6 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_HealthCheck.ps1 -Dev -ScriptInfo -Log
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named PVSHealthCheckScriptErrors_yyyy-MM-dd_HHmm.txt that
-\par \hich\af2\dbch\af31505\loch\f2     contains up to the last 250 errors report\hich\af2\dbch\af31505\loch\f2 ed by the script.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named PVSHealthCheckScriptErr\hich\af2\dbch\af31505\loch\f2 ors_yyyy-MM-dd_HHmm.txt that
+\par \hich\af2\dbch\af31505\loch\f2     contains up to the last 250 errors reported by the script.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a text file named PVSHealthCheckScriptInfo_yyyy-MM-dd_HHmm.txt that
 \par \hich\af2\dbch\af31505\loch\f2     contains all the script parameters and other basic information.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a text file for transcript logging named
-\par \hich\af2\dbch\af31505\loch\f2     PVSHealthCheckScriptTranscript_\hich\af2\dbch\af31505\loch\f2 yyyy-MM-dd_HHmm.txt.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a \hich\af2\dbch\af31505\loch\f2 text file for transcript logging named
+\par \hich\af2\dbch\af31505\loch\f2     PVSHealthCheckScriptTranscript_yyyy-MM-dd_HHmm.txt.
 \par 
 \par 
 \par 
@@ -529,7 +529,7 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     LocalHost for AdminAddress.
-\par \hich\af2\dbch\af31505\loch\f2     Crea\hich\af2\dbch\af31505\loch\f2 tes a CSV file for each Appendix.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a CSV file for each Appendix.
 \par 
 \par 
 \par 
@@ -538,16 +538,16 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_HealthCheck.ps1
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer mail.domain.tld
-\par \hich\af2\dbch\af31505\loch\f2     -From XDAdmin@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   -From XDAdmin@domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@domain.tld
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script wil\hich\af2\dbch\af31505\loch\f2 l use the email server mail.domain.tld, sending from XDAdmin@domain.tld,
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld,
 \par \hich\af2\dbch\af31505\loch\f2     sending to ITGroup@domain.tld.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will not use SSL.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
-\par \hich\af2\dbch\af31505\loch\f2     the \hich\af2\dbch\af31505\loch\f2 user will be prompted to enter valid credentials.
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   If the current user's credentials are not valid to send email,
+\par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
 \par 
 \par 
 \par 
@@ -562,27 +562,27 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     ***SENDING UNAUTHENTICATED EMAIL***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the email server mailrelay.domain.tld, sending from
-\par \hich\af2\dbch\af31505\loch\f2     anonymous@domain.tld, sending to ITGroup@domain.tld.
+\par \hich\af2\dbch\af31505\loch\f2     anonymous@domain.tld, sending to ITGrou\hich\af2\dbch\af31505\loch\f2 p@domain.tld.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     To send unauthenticated email using an email rela\hich\af2\dbch\af31505\loch\f2 y server requires the From email account
+\par \hich\af2\dbch\af31505\loch\f2     To send unauthenticated email using an email relay server requires the From email account
 \par \hich\af2\dbch\af31505\loch\f2     to use the name Anonymous.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will not use SSL.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid9244280 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 \hich\af2\dbch\af31505\loch\f2  HYP\hich\af2\dbch\af31505\loch\f2 ERLINK "https://support.google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00039f12e7000051}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00039f12e70000510000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid9244280 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "htt\hich\af2\dbch\af31505\loch\f2 ps://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030020b0000000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030020b00000000000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail or g-suite account, you may have to turn ON
-\par \hich\af2\dbch\af31505\loch\f2     the "Less secure app ac\hich\af2\dbch\af31505\loch\f2 cess" option on your account.
+\par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail \hich\af2\dbch\af31505\loch\f2 or g-suite account, you may have to turn ON
+\par \hich\af2\dbch\af31505\loch\f2     the "Less secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will generate an anonymous secure password for the anonymous@domain.tld
@@ -591,7 +591,7 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 10 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -----------\hich\af2\dbch\af31505\loch\f2 --------------- EXAMPLE 10 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_HealthCheck.ps1
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer labaddomain-com.mail.protection.outlook.com
@@ -601,41 +601,40 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://docs.micro\hich\af2\dbch\af31505\loch\f2 
-soft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 \hich\af2\dbch\af31505\loch\f2 
+ HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900660075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab0003010000000000}}}{\fldrslt {
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 
-https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid9244280\charrsid9244280 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab000301000000000000e6}}}{\fldrslt {
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-pra\hich\af2\dbch\af31505\loch\f2 
+ctices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Thi\hich\af2\dbch\af31505\loch\f2 s uses Option 2 from the above link.
+\par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the email server labaddomain-com.mail.protection.outlook.com,
-\par \hich\af2\dbch\af31505\loch\f2     sending from SomeEmailAddress@labaddomain.com, sending to ITGroupDL@labaddomain.com.
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  sending from SomeEmailAddress@labaddomain.com, sending to ITGroupDL@labaddomain.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The scri\hich\af2\dbch\af31505\loch\f2 pt will use the default SMTP port 25 and will use SSL.
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will use SSL.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 11 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_HealthCheck.ps1
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_He\hich\af2\dbch\af31505\loch\f2 althCheck.ps1
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer smtp.office365.com
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort 587
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL
-\par \hich\af2\dbch\af31505\loch\f2     -Fr\hich\af2\dbch\af31505\loch\f2 om Webster@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     -From Webster@CarlWebster.com
 \par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp.office365.com on port 587 using SSL,
 \par \hich\af2\dbch\af31505\loch\f2     sending from webster@carlwebster.com, sending to ITGroup@carlwebster.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credenti\hich\af2\dbch\af31505\loch\f2 als are not valid to send email,
-\par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
+\par \hich\af2\dbch\af31505\loch\f2     the user will be prompt\hich\af2\dbch\af31505\loch\f2 ed to enter valid credentials.
 \par 
 \par 
 \par 
@@ -647,17 +646,17 @@ https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort 587
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL
 \par \hich\af2\dbch\af31505\loch\f2     -From Webster@CarlWebster.com
-\par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     -To ITGrou\hich\af2\dbch\af31505\loch\f2 p@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
 \par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail or g-suite account, you may have to turn ON
 \par \hich\af2\dbch\af31505\loch\f2     the "Less secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The s\hich\af2\dbch\af31505\loch\f2 cript will use the email server smtp.gmail.com on port 587 using SSL,
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp.gmail.com on port 587 u\hich\af2\dbch\af31505\loch\f2 sing SSL,
 \par \hich\af2\dbch\af31505\loch\f2     sending from webster@gmail.com, sending to ITGroup@carlwebster.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the cur\hich\af2\dbch\af31505\loch\f2 rent user's credentials are not valid to send email,
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
 \par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
 \par 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 
@@ -781,8 +780,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000206e
-366979dfd601feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000307e
+96a8b3e5d601feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/PVS_HealthCheck_Script_ChangeLog.txt
+++ b/PVS_HealthCheck_Script_ChangeLog.txt
@@ -3,6 +3,43 @@
 #@carlwebster on Twitter
 #http://www.CarlWebster.com
 
+#Version 1.23
+#	Added Appendix P - Items to Review
+#		Auditing is not enabled
+#		Offline database support is not enabled
+#		Problem report Citrix Username is <Name/ID>
+#		<ServerName> event logging is not enabled
+#	Added Appendix Q - Server Items to Review
+#		Computer Items to Review
+#		Drive Items to Review
+#		Processor Items to Review
+#		NIC Items to Review
+#	Added the following CSV files:
+#		PVSFarm_HealthCheck_AppendixP_ItemsToReview.csv
+#		PVSFarm_HealthCheck_AppendixQ_ServerComputerItemsToReview.csv
+#		PVSFarm_HealthCheck_AppendixQ_ServerDriveItemsToReview.csv
+#		PVSFarm_HealthCheck_AppendixQ_ServerProcessorItemsToReview.csv
+#		PVSFarm_HealthCheck_AppendixQ_ServerNICItemsToReview.csv
+#	Added to the Farm info, the Security and Groups tabs (requested by JLuhring)
+#	Added to the Farm info if the PVS version is >= 7.11, the Problem Report Citrix Username (requested by JLuhring)
+#	Added to the vDisks in Farm section:
+#		Recommended RAM for each PVS Server using XA & XD vDisks
+#	Added to the Computer Hardware section, the server's Power Plan (requested by JLuhring)
+#	Changed all Verbose statements from Get-Date to Get-Date -Format G as requested by Guy Leech
+#	Changed the default Domain value to $env:UserDomain
+#	Changed the default User value to $env:username
+#		Combine the two values for the call to Get-Credential
+#	Changed the variable PVSFullVersion to type [version] for better comparisons
+#	Check for the McliPSSnapIn snapin before installing the .Net snapins
+#		If the snapin already exists, there was no need to install and register the .Net V2 and V4 snapins for every script run
+#	Cleaned up alignment for most of the output
+#	Removed the Password parameter to keep from having the password entered as plaintext
+#		Use Get-Credential and code from Frank Lindenblatt to get the password from the $credential object
+#		The mcli-run SetupConnection uses only a plaintext password
+#	Reordered parameters in an order recommended by Guy Leech
+#	Updated the help text
+#	Updated the ReadMe file
+
 #Version 1.22 28-Apr-2020
 #	Add -Dev, -Log, and -ScriptInfo parameters (Thanks to Guy Leech for the push)
 #	Add Function ProcessScriptEnd

--- a/PVS_HealthCheck_Script_ChangeLog.txt
+++ b/PVS_HealthCheck_Script_ChangeLog.txt
@@ -3,7 +3,7 @@
 #@carlwebster on Twitter
 #http://www.CarlWebster.com
 
-#Version 1.23
+#Version 1.23 8-Jan-2021
 #	Added Appendix P - Items to Review
 #		Auditing is not enabled
 #		Offline database support is not enabled
@@ -27,6 +27,7 @@
 #		Recommended RAM for each PVS Server using XA & XD vDisks
 #	Added to the Computer Hardware section, the server's Power Plan (requested by JLuhring)
 #	Changed all Verbose statements from Get-Date to Get-Date -Format G as requested by Guy Leech
+#	Changed getting the path for the PVS snapin from the environment variable for "ProgramFiles" to the console installation path (Thanks to Guy Leech)
 #	Changed the default Domain value to $env:UserDomain
 #	Changed the default User value to $env:username
 #		Combine the two values for the call to Get-Credential
@@ -34,7 +35,7 @@
 #	Check for the McliPSSnapIn snapin before installing the .Net snapins
 #		If the snapin already exists, there was no need to install and register the .Net V2 and V4 snapins for every script run
 #	Cleaned up alignment for most of the output
-#	Fixed the missing $DatacenterLicense variable (found by SHurjuk)
+#	Fixed the missing $DatacenterLicense variable (found by @salimhurjuk)
 #	Removed the Password parameter to keep from having the password entered as plaintext
 #		Use Get-Credential and code from Frank Lindenblatt to get the password from the $credential object
 #		The mcli-run SetupConnection uses only a plaintext password

--- a/PVS_HealthCheck_Script_ChangeLog.txt
+++ b/PVS_HealthCheck_Script_ChangeLog.txt
@@ -20,6 +20,7 @@
 #		PVSFarm_HealthCheck_AppendixQ_ServerDriveItemsToReview.csv
 #		PVSFarm_HealthCheck_AppendixQ_ServerProcessorItemsToReview.csv
 #		PVSFarm_HealthCheck_AppendixQ_ServerNICItemsToReview.csv
+#	Added testing for standard Windows folders to keep people from running the script in folders like c:\windows\system32
 #	Added to the Farm info, the Security and Groups tabs (requested by JLuhring)
 #	Added to the Farm info if the PVS version is >= 7.11, the Problem Report Citrix Username (requested by JLuhring)
 #	Added to the vDisks in Farm section:
@@ -33,6 +34,7 @@
 #	Check for the McliPSSnapIn snapin before installing the .Net snapins
 #		If the snapin already exists, there was no need to install and register the .Net V2 and V4 snapins for every script run
 #	Cleaned up alignment for most of the output
+#	Fixed the missing $DatacenterLicense variable (found by SHurjuk)
 #	Removed the Password parameter to keep from having the password entered as plaintext
 #		Use Get-Credential and code from Frank Lindenblatt to get the password from the $credential object
 #		The mcli-run SetupConnection uses only a plaintext password


### PR DESCRIPTION
#Version 1.23 8-Jan-2021
#	Added Appendix P - Items to Review
#		Auditing is not enabled
#		Offline database support is not enabled
#		Problem report Citrix Username is <Name/ID>
#		<ServerName> event logging is not enabled
#	Added Appendix Q - Server Items to Review
#		Computer Items to Review
#		Drive Items to Review
#		Processor Items to Review
#		NIC Items to Review
#	Added the following CSV files:
#		PVSFarm_HealthCheck_AppendixP_ItemsToReview.csv
#		PVSFarm_HealthCheck_AppendixQ_ServerComputerItemsToReview.csv
#		PVSFarm_HealthCheck_AppendixQ_ServerDriveItemsToReview.csv
#		PVSFarm_HealthCheck_AppendixQ_ServerProcessorItemsToReview.csv
#		PVSFarm_HealthCheck_AppendixQ_ServerNICItemsToReview.csv
#	Added testing for standard Windows folders to keep people from running the script in folders like c:\windows\system32
#	Added to the Farm info, the Security and Groups tabs (requested by JLuhring)
#	Added to the Farm info if the PVS version is >= 7.11, the Problem Report Citrix Username (requested by JLuhring)
#	Added to the vDisks in Farm section:
#		Recommended RAM for each PVS Server using XA & XD vDisks
#	Added to the Computer Hardware section, the server's Power Plan (requested by JLuhring)
#	Changed all Verbose statements from Get-Date to Get-Date -Format G as requested by Guy Leech
#	Changed getting the path for the PVS snapin from the environment variable for "ProgramFiles" to the console installation path (Thanks to Guy Leech)
#	Changed the default Domain value to $env:UserDomain
#	Changed the default User value to $env:username
#		Combine the two values for the call to Get-Credential
#	Changed the variable PVSFullVersion to type [version] for better comparisons
#	Check for the McliPSSnapIn snapin before installing the .Net snapins
#		If the snapin already exists, there was no need to install and register the .Net V2 and V4 snapins for every script run
#	Cleaned up alignment for most of the output
#	Fixed the missing $DatacenterLicense variable (found by @salimhurjuk)
#	Removed the Password parameter to keep from having the password entered as plaintext
#		Use Get-Credential and code from Frank Lindenblatt to get the password from the $credential object
#		The mcli-run SetupConnection uses only a plaintext password
#	Reordered parameters in an order recommended by Guy Leech
#	Updated the help text
#	Updated the ReadMe file